### PR TITLE
Add icon example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CA1416: Validate platform compatibility
+dotnet_diagnostic.CA1416.severity = none

--- a/EFTHelper.sln
+++ b/EFTHelper.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFTHelper", "src\EFTHelper.csproj", "{3F150B20-C834-4ED6-8E92-DA479052BB0D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{21790E7F-5B9B-4FB2-8FD9-68037D51BBE0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/EFTHelper.csproj
+++ b/src/EFTHelper.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Resource Include="Fonts\bender.regular.otf">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>

--- a/src/Models/IMenuItem.cs
+++ b/src/Models/IMenuItem.cs
@@ -8,7 +8,7 @@
 
         public string Title { get; }
 
-        public string Icon { get; }
+        public object Icon { get; }
 
         #endregion
     }

--- a/src/ViewModels/ItemTypeViewModel.cs
+++ b/src/ViewModels/ItemTypeViewModel.cs
@@ -2,6 +2,7 @@
 using EFTHelper.Enums;
 using EFTHelper.Extensions;
 using EFTHelper.Models;
+using MahApps.Metro.IconPacks;
 
 namespace EFTHelper.ViewModels
 {
@@ -18,6 +19,7 @@ namespace EFTHelper.ViewModels
         public ItemTypeViewModel(ItemTypes itemType)
         {
             _itemType = itemType;
+            Icon = BuildIcon(_itemType);
         }
 
         #endregion
@@ -28,9 +30,44 @@ namespace EFTHelper.ViewModels
 
         public string Title => _itemType.ToString().ToSentence();
 
-        public string Icon { get; }
+        public object Icon { get; }
 
         public ItemTypes ItemType => _itemType;
+
+        #endregion
+
+        #region Methods
+
+        private static PackIconBase BuildIcon(ItemTypes itemType)
+        {
+            PackIconBase icon = null;
+            switch (itemType)
+            {
+                case ItemTypes.Any:
+                    icon = new PackIconFontAwesome() { Kind = PackIconFontAwesomeKind.AsteriskSolid };
+                    break;
+                case ItemTypes.Ammo:
+                    icon = new PackIconMaterial() { Kind = PackIconMaterialKind.Ammunition };
+                    break;
+                case ItemTypes.AmmoBox:
+                    icon = new PackIconRPGAwesome() { Kind = PackIconRPGAwesomeKind.AmmoBag };
+                    break;
+                case ItemTypes.Armor:
+                    icon = new PackIconRemixIcon() { Kind = PackIconRemixIconKind.TShirt2Fill};
+                    break;
+                case ItemTypes.Backpack:
+                    icon = new PackIconUnicons() { Kind = PackIconUniconsKind.Backpack };
+                    break;
+            }
+
+            if (icon != null) 
+            { 
+                icon.Width = 24;
+                icon.Height = 24;
+            }
+
+            return icon;
+        }
 
         #endregion
     }

--- a/src/ViewModels/LocationViewModel.cs
+++ b/src/ViewModels/LocationViewModel.cs
@@ -27,7 +27,7 @@ namespace EFTHelper.ViewModels
 
         public string Title => Name;
 
-        public string Icon => Label;
+        public object Icon => null;
 
         #endregion
     }

--- a/src/Views/ItemsListView.xaml
+++ b/src/Views/ItemsListView.xaml
@@ -28,11 +28,13 @@
                         <ColumnDefinition Width="48" />
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
-                    <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding Icon}"/>
+                    <ContentControl HorizontalAlignment="Center" 
+                               VerticalAlignment="Center" 
+                               Content="{Binding Icon}"/>
                     <TextBlock Grid.Column="1"
-           VerticalAlignment="Center"
-           FontSize="16"
-           Text="{Binding Label}" />
+                               VerticalAlignment="Center"
+                               FontSize="16"
+                               Text="{Binding Label}" />
                 </Grid>
             </DataTemplate>
         </ResourceDictionary>


### PR DESCRIPTION
The `editor.config` is added since we had a warning concerning the type switch not supported for `arm` devices...

I disabled the warning.